### PR TITLE
Add rspec-its gem

### DIFF
--- a/emojimmy.gemspec
+++ b/emojimmy.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec-its'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'sqlite3'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'coveralls'
 Coveralls.wear!
 
 require 'rspec'
+require 'rspec/its'
 require 'sqlite3'
 require 'emojimmy'
 


### PR DESCRIPTION
This PR will fix following error on spec.

``` shell-session
$ bundle exec rake spec
/Users/mizoR/.rbenv/versions/2.1.1/bin/ruby -I/Users/mizoR/.ghq/github.com/mizoR/emojimmy/.bundle/bundle/ruby/2.1.0/gems/rspec-core-3.0.2/lib:/Users/mizoR/.ghq/github.com/mizoR/emojimmy/.bundle/bundle/ruby/2.1.0/gems/rspec-support-3.0.2/lib -S /Users/mizoR/.ghq/github.com/mizoR/emojimmy/.bundle/bundle/ruby/2.1.0/gems/rspec-core-3.0.2/exe/rspec spec/emojimmy/mixin_spec.rb spec/emojimmy_spec.rb
/Users/mizoR/.ghq/github.com/mizoR/emojimmy/spec/emojimmy/mixin_spec.rb:37:in `block (5 levels) in <top (required)>': undefined method `its' for #<Class:0x007fd80363e830> (NoMethodError)
```

> - Extract `its` support to a separate gem. (Peter Alfvin)
> 
> ref: https://github.com/rspec/rspec-core/blob/master/Changelog.md#300beta1--2013-11-07
