### PR TITLE
Exception when the database is non-existant

### DIFF
--- a/lib/emojimmy/extensions.rb
+++ b/lib/emojimmy/extensions.rb
@@ -1,6 +1,10 @@
 class ActiveRecord::Base
   def self.stores_emoji_characters(*attributes)
-    return unless table_exists?
+    begin
+      return unless table_exists?
+    rescue ActiveRecord::NoDatabaseError
+      return
+    end
 
     Emojimmy::Mixin.inject_methods(self, attributes)
   end


### PR DESCRIPTION
Letting the exception be raised will break most tasks, including `rake db:create`
