### PR TITLE
Don't let false values halt callback chain, preventing record to be persisted

### DIFF
--- a/lib/emojimmy/mixin.rb
+++ b/lib/emojimmy/mixin.rb
@@ -10,6 +10,7 @@ module Emojimmy
             end
 
             self.#{attribute} = Emojimmy.emoji_to_token(self.#{attribute})
+            true
           end
 
           # When calling the attribute name, convert its value

--- a/spec/emojimmy/mixin_spec.rb
+++ b/spec/emojimmy/mixin_spec.rb
@@ -77,6 +77,11 @@ describe Emojimmy::Mixin do
           it { should be_persisted }
           it { expect(persisted_body).to eql "Hello, boring world!" }
         end
+
+        context 'with false value' do
+          let(:body) { false }
+          it { should be_persisted }
+        end
       end
     end
   end


### PR DESCRIPTION
When value is false, the before_save callback stops the record from persisting in Rails 4.